### PR TITLE
[BUG FIX] Kill PetscOptionsBegin/End from setUpGenEOPCFromOptions.

### DIFF
--- a/src/geneo.cpp
+++ b/src/geneo.cpp
@@ -2273,7 +2273,6 @@ string usageGenEO(bool const petscPrintf) {
   msg << "                   L2 =    H2 =           hybrid GenEO-2 (1st level [proj. fine space] +  2d level [coarse space])" << endl;
   msg << "                   L2 =    E2 = efficient hybrid GenEO-2 (initial guess [coarse space] + 1st level [proj. fine space])" << endl;
   msg << "                   you can pass arguments to PETSc / SLEPc solvers at the command line using prefix:" << endl;
-  msg << "                     -igs_  for iterative   global solve:           -igs_ksp_atol 1.e-06 -igs_ksp_rtol 1.e-06" << endl;
   msg << "                     -dls1_ for      direct  local solve (level 1): -dls1_pc_factor_mat_solver_package mumps" << endl;
   msg << "                     -syl2_ for   sylvester  local solve (level 2): -syl2_ksp_view" << endl;
   msg << "                     -els2_ for       eigen  local solve (level 2): -els2_eps_max_it 100 -els2_eps_type arnoldi" << endl;
@@ -2293,6 +2292,9 @@ string usageGenEO(bool const petscPrintf) {
   msg << "  -geneo_no_syl    do not use Sylvester's law (inertia) to estimate the number of eigen values used to build Z" << endl;
   msg << "                   in case the eigen solver handles this estimation (krylovschur), you don't need to do it" << endl;
   msg << "  -geneo_offload   offload Z and E at master side (gather inputs, local solve, scatter outputs)" << endl;
+  msg << "" << endl;
+  msg << "In case a problem occurs, the following options may help:" << endl;
+  msg << "" << endl;
   msg << "  -geneo_dbg F,D   create debug files" << endl;
   msg << "                   F = log (ASCII file), bin (binary file) or mat (matlab file)" << endl;
   msg << "                   D = 1: timing and residual" << endl;
@@ -2317,8 +2319,6 @@ static PetscErrorCode setUpGenEOPCFromOptions(PetscOptionItems * PetscOptionsObj
   // Check arguments.
 
   PetscErrorCode pcRC = PetscOptionsHead(PetscOptionsObject, "GenEO options");
-  CHKERRQ(pcRC);
-  pcRC = PetscOptionsBegin(PETSC_COMM_WORLD, NULL, "GenEO options", "GenEO options");
   CHKERRQ(pcRC);
 
   PetscBool pcHasOpt = PETSC_FALSE;
@@ -2461,8 +2461,6 @@ static PetscErrorCode setUpGenEOPCFromOptions(PetscOptionItems * PetscOptionsObj
     gCtx->check = true;
   }
 
-  pcRC = PetscOptionsEnd();
-  CHKERRQ(pcRC);
   pcRC = PetscOptionsTail();
   CHKERRQ(pcRC);
 

--- a/src/geneo4PETSc.cpp
+++ b/src/geneo4PETSc.cpp
@@ -1328,8 +1328,6 @@ int solve(unsigned int const & nbDOF, unsigned int const & nbSubMat,
   KSP pcKSP;
   pcRC = KSPCreate(PETSC_COMM_WORLD, &pcKSP); // Global solve (shared by all MPI proc).
   CHKERRQ(pcRC);
-  pcRC = KSPSetOptionsPrefix(pcKSP, "igs_");
-  CHKERRQ(pcRC);
   pcRC = PCRegister("geneo", createGenEOPC);
   CHKERRQ(pcRC);
   PC pcPC;

--- a/tst/dummy/dummy.sh
+++ b/tst/dummy/dummy.sh
@@ -5,27 +5,27 @@ echo "" # Add space for clarity.
 
 for f in "identity" "tridiag"
 do
-  for p in "-igs_pc_type#bjacobi"                                  \
-           "-igs_pc_type#geneo#-geneo_lvl#ASM,0"                   \
-           "-igs_pc_type#geneo#-geneo_lvl#ASM,1"                   \
-           "-igs_pc_type#geneo#-geneo_lvl#ASM,1##--addOverlap#1"   \
-           "-igs_pc_type#geneo#-geneo_lvl#ASM,1##-geneo_offload"   \
-           "-igs_pc_type#geneo#-geneo_lvl#ASM,H1"                  \
-           "-igs_pc_type#geneo#-geneo_lvl#ASM,H1#--addOverlap#1"   \
-           "-igs_pc_type#geneo#-geneo_lvl#ASM,H1#-geneo_offload"   \
-           "-igs_pc_type#geneo#-geneo_lvl#ASM,E1"                  \
-           "-igs_pc_type#geneo#-geneo_lvl#ASM,E1#--addOverlap#1"   \
-           "-igs_pc_type#geneo#-geneo_lvl#ASM,E1#-geneo_offload"   \
-           "-igs_pc_type#geneo#-geneo_lvl#SORAS,0"                 \
-           "-igs_pc_type#geneo#-geneo_lvl#SORAS,2"                 \
-           "-igs_pc_type#geneo#-geneo_lvl#SORAS,2##--addOverlap#1" \
-           "-igs_pc_type#geneo#-geneo_lvl#SORAS,2##-geneo_offload" \
-           "-igs_pc_type#geneo#-geneo_lvl#SORAS,H2"                \
-           "-igs_pc_type#geneo#-geneo_lvl#SORAS,H2#--addOverlap#1" \
-           "-igs_pc_type#geneo#-geneo_lvl#SORAS,H2#-geneo_offload" \
-           "-igs_pc_type#geneo#-geneo_lvl#SORAS,E2"                \
-           "-igs_pc_type#geneo#-geneo_lvl#SORAS,E2#--addOverlap#1" \
-           "-igs_pc_type#geneo#-geneo_lvl#SORAS,E2#-geneo_offload"
+  for p in "-pc_type#bjacobi"                                  \
+           "-pc_type#geneo#-geneo_lvl#ASM,0"                   \
+           "-pc_type#geneo#-geneo_lvl#ASM,1"                   \
+           "-pc_type#geneo#-geneo_lvl#ASM,1##--addOverlap#1"   \
+           "-pc_type#geneo#-geneo_lvl#ASM,1##-geneo_offload"   \
+           "-pc_type#geneo#-geneo_lvl#ASM,H1"                  \
+           "-pc_type#geneo#-geneo_lvl#ASM,H1#--addOverlap#1"   \
+           "-pc_type#geneo#-geneo_lvl#ASM,H1#-geneo_offload"   \
+           "-pc_type#geneo#-geneo_lvl#ASM,E1"                  \
+           "-pc_type#geneo#-geneo_lvl#ASM,E1#--addOverlap#1"   \
+           "-pc_type#geneo#-geneo_lvl#ASM,E1#-geneo_offload"   \
+           "-pc_type#geneo#-geneo_lvl#SORAS,0"                 \
+           "-pc_type#geneo#-geneo_lvl#SORAS,2"                 \
+           "-pc_type#geneo#-geneo_lvl#SORAS,2##--addOverlap#1" \
+           "-pc_type#geneo#-geneo_lvl#SORAS,2##-geneo_offload" \
+           "-pc_type#geneo#-geneo_lvl#SORAS,H2"                \
+           "-pc_type#geneo#-geneo_lvl#SORAS,H2#--addOverlap#1" \
+           "-pc_type#geneo#-geneo_lvl#SORAS,H2#-geneo_offload" \
+           "-pc_type#geneo#-geneo_lvl#SORAS,E2"                \
+           "-pc_type#geneo#-geneo_lvl#SORAS,E2#--addOverlap#1" \
+           "-pc_type#geneo#-geneo_lvl#SORAS,E2#-geneo_offload"
   do
     l="log"
     if [[ "${p}" == *"identity"*   ]]; then l="mat"; fi
@@ -35,12 +35,12 @@ do
     do
       PC_CMD="${p//[#]/ }"
       PC_LOG="${p//[#]/}"; PC_LOG="${PC_LOG//-/}"; PC_LOG="${PC_LOG//,/}"
-      PC_LOG="${PC_LOG//igs_pc_type/}"; PC_LOG="${PC_LOG//addOverlap1/}"
+      PC_LOG="${PC_LOG//pc_type/}"; PC_LOG="${PC_LOG//addOverlap1/}"
       PC_LOG="${PC_LOG//geneo_lvl/}"; PC_LOG="${PC_LOG//geneo_offload/}"
 
       OPT_LOG="${p//[#]/}"; OPT_LOG="${OPT_LOG//-/}"; OPT_LOG="${OPT_LOG//,/}"
       OPT_LOG="${OPT_LOG//geneo_offload/offload}"; OPT_LOG="${OPT_LOG//addOverlap/overlap}"
-      OPT_LOG="${OPT_LOG//igs_pc_type/}"
+      OPT_LOG="${OPT_LOG//pc_type/}"
       OPT_LOG="${OPT_LOG//bjacobi/}"
       OPT_LOG="${OPT_LOG//geneo_lvl/}"; OPT_LOG="${OPT_LOG//geneo/}"
       OPT_LOG="${OPT_LOG//ASM0/}"; OPT_LOG="${OPT_LOG//ASM1/}"; OPT_LOG="${OPT_LOG//ASMH1/}"; OPT_LOG="${OPT_LOG//ASME1/}"
@@ -56,7 +56,7 @@ do
       if [[ "${f}" == "identity" ]]; then CMD="${CMD} --inpFileB B.inp"; fi
       if [[ "${f}" == "tridiag" ]]; then CMD="${CMD} --inpEps 1. -geneo_cut 10"; fi # Add (useless !) -geneo_cut for coverage.
       CMD="${CMD} ${PC_CMD} --debug ${l} --verbose 2 -geneo_chk log -geneo_dbg ${l},2 --shortRes"
-      CMD="${CMD} -igs_ksp_atol 1.e-12 -igs_ksp_rtol 1.e-12" # Use tolerance to make "make test" as stable as possible.
+      CMD="${CMD} -ksp_atol 1.e-12 -ksp_rtol 1.e-12" # Use tolerance to make "make test" as stable as possible.
       CMD="${CMD} -options_left no" # Get rid of unused option warnings with options_left (get clean logs).
       CMD="${CMD} ${m}"
       echo "$CMD" # Add command in the log: convienient to relaunch manually when problem occurs.

--- a/tst/graph/graphRun.sh
+++ b/tst/graph/graphRun.sh
@@ -25,30 +25,30 @@ WEAK_INP_LEVEL="2"
 WEAK_MPI="${STRONG_MPI}"
 METIS=("--metisDual" "--metisNodal")
 TOL="1.e-04 1.e-05"
-PC="-igs_pc_type#bjacobi -igs_pc_type#mg"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#ASM,0"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#ASM,1"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#ASM,1##--addOverlap#1"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#ASM,1##-geneo_offload"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#ASM,H1"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#ASM,H1#--addOverlap#1"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#ASM,H1#-geneo_offload"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#ASM,E1"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#ASM,E1#--addOverlap#1"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#ASM,E1#-geneo_offload"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#SORAS,0"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#SORAS,2"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#SORAS,2##--addOverlap#1"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#SORAS,2##-geneo_offload"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#SORAS,H2"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#SORAS,H2#--addOverlap#1"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#SORAS,H2#-geneo_offload"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#SORAS,E2"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#SORAS,E2#--addOverlap#1"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#SORAS,E2#-geneo_offload"
-IGS_TYPE_OPT=("-igs_ksp_type#gmres") # "-igs_ksp_type#cg")
-IGS_OPT="-igs_ksp_max_it 1000 -igs_ksp_gmres_restart 1000" # Forbid GMRES restart (by imposing restart = max its).
-IGS_OPT="${IGS_OPT} -options_left no" # Get rid of unused option warnings with options_left (get clean logs).
+PC="-pc_type#bjacobi -pc_type#mg"
+PC="${PC} -pc_type#geneo#-geneo_lvl#ASM,0"
+PC="${PC} -pc_type#geneo#-geneo_lvl#ASM,1"
+PC="${PC} -pc_type#geneo#-geneo_lvl#ASM,1##--addOverlap#1"
+PC="${PC} -pc_type#geneo#-geneo_lvl#ASM,1##-geneo_offload"
+PC="${PC} -pc_type#geneo#-geneo_lvl#ASM,H1"
+PC="${PC} -pc_type#geneo#-geneo_lvl#ASM,H1#--addOverlap#1"
+PC="${PC} -pc_type#geneo#-geneo_lvl#ASM,H1#-geneo_offload"
+PC="${PC} -pc_type#geneo#-geneo_lvl#ASM,E1"
+PC="${PC} -pc_type#geneo#-geneo_lvl#ASM,E1#--addOverlap#1"
+PC="${PC} -pc_type#geneo#-geneo_lvl#ASM,E1#-geneo_offload"
+PC="${PC} -pc_type#geneo#-geneo_lvl#SORAS,0"
+PC="${PC} -pc_type#geneo#-geneo_lvl#SORAS,2"
+PC="${PC} -pc_type#geneo#-geneo_lvl#SORAS,2##--addOverlap#1"
+PC="${PC} -pc_type#geneo#-geneo_lvl#SORAS,2##-geneo_offload"
+PC="${PC} -pc_type#geneo#-geneo_lvl#SORAS,H2"
+PC="${PC} -pc_type#geneo#-geneo_lvl#SORAS,H2#--addOverlap#1"
+PC="${PC} -pc_type#geneo#-geneo_lvl#SORAS,H2#-geneo_offload"
+PC="${PC} -pc_type#geneo#-geneo_lvl#SORAS,E2"
+PC="${PC} -pc_type#geneo#-geneo_lvl#SORAS,E2#--addOverlap#1"
+PC="${PC} -pc_type#geneo#-geneo_lvl#SORAS,E2#-geneo_offload"
+KSP_OPT=("-ksp_type#gmres") # "-ksp_type#cg")
+OPT="-ksp_max_it 1000 -ksp_gmres_restart 1000" # Forbid GMRES restart (by imposing restart = max its).
+OPT="${OPT} -options_left no" # Get rid of unused option warnings with options_left (get clean logs).
 GENEO_L1_DLS=("-dls1_pc_factor_mat_solver_package#mumps") # "-dls1_pc_factor_mat_solver_package#superlu")
 GENEO_L1_OPTIM=("-geneo_optim#0.00" "-geneo_optim#0.02")
 GENEO_L2_TAU_GAMMA=("-geneo_tau#0.1#-geneo_gamma#8." "-geneo_tau#0.2#-geneo_gamma#12.")
@@ -57,7 +57,7 @@ GENEO_L2_ELS_OPT="-els2_eps_max_it 50" # Caution: the more iterations are perfor
 GENEO_L2_ELS_TOL="-els2_eps_tol 1.e-02" # Caution: the most precise the tolerance is, the more the eigen solve is costly.
 GENEO_OPT="" # "-geneo_cut 10"
 MUMPS_OPT="-mat_mumps_cntl_1 0.01 -mat_mumps_cntl_3 -0.00001 -mat_mumps_cntl_4 0.00001" # Pivoting thresholds (mandatory for physical cases).
-MG_OPT="-igs_pc_mg_cycle_type w -igs_pc_mg_smoothup 5 -igs_pc_mg_smoothdown 5"
+MG_OPT="-pc_mg_cycle_type w -pc_mg_smoothup 5 -pc_mg_smoothdown 5"
 SUPERLU_OPT="-mat_superlu_replacetinypivot -mat_superlu_equil -mat_superlu_rowperm LargeDiag -mat_superlu_colperm NATURAL"
 SUPERLUDIST_OPT="-mat_superlu_dist_replacetinypivot -mat_superlu_dist_equil -mat_superlu_dist_rowperm LargeDiag -mat_superlu_dist_colperm NATURAL"
 VERBOSE="NO"
@@ -94,9 +94,9 @@ do
         do
           for p in "${PC_ARRAY[@]}"
           do
-            for k in "${IGS_TYPE_OPT[@]}"
+            for k in "${KSP_OPT[@]}"
             do
-              OTHER_OPT="${IGS_OPT}"
+              OTHER_OPT="${OPT}"
 
               unset OPT_ARRAY
               if [[ "${p}" == *"bjacobi"* ]]; then
@@ -138,14 +138,14 @@ do
                 INP="--inpLibA ./@CMAKE_SHARED_LIBRARY_PREFIX@gengraph@CMAKE_SHARED_LIBRARY_SUFFIX@"
                 INP="${INP} --size#${s}#--level#${l}#--weakScaling#${w}#--noGround#--debug#--inpEps#0.0001"
 
-                EPS="-igs_ksp_atol ${t} -igs_ksp_rtol ${t}";
+                EPS="-ksp_atol ${t} -ksp_rtol ${t}";
                 if [[ "${p}" == *"geneo"*"1"* ]] || [[ "${p}" == *"geneo"*"2"* ]]; then # GenEO-1, GenEO-2.
                   EPS="${EPS} ${GENEO_L2_ELS_TOL}";
                 fi
 
                 KSP_CMD="${k//[#]/ }"
                 KSP_LOG="${k//[#]/}"; KSP_LOG="${KSP_LOG//-/}"
-                KSP_LOG="${KSP_LOG//igs_ksp_type/}"
+                KSP_LOG="${KSP_LOG//ksp_type/}"
 
                 OPT_CMD="${o//[#]/ }"
                 OPT_LOG="${o//[#]/:}"; OPT_LOG="${OPT_LOG//-/}"
@@ -155,7 +155,7 @@ do
 
                 PC_CMD="${p//[#]/ }"
                 PC_LOG="${p//[#]/}"; PC_LOG="${PC_LOG//-/}"; PC_LOG="${PC_LOG//,/}"
-                PC_LOG="${PC_LOG//igs_pc_type/}"; PC_LOG="${PC_LOG//addOverlap/overlap}"
+                PC_LOG="${PC_LOG//pc_type/}"; PC_LOG="${PC_LOG//addOverlap/overlap}"
                 PC_LOG="${PC_LOG//geneo_lvl/}"; PC_LOG="${PC_LOG//geneo_offload/offload}"
 
                 unset CMD

--- a/tst/laplacian/laplacianRun.sh
+++ b/tst/laplacian/laplacianRun.sh
@@ -23,30 +23,30 @@ WEAK_INP_SIZE="5"
 WEAK_MPI="${STRONG_MPI}"
 METIS=("--metisDual" "--metisNodal")
 TOL="1.e-04 1.e-05"
-PC="-igs_pc_type#bjacobi -igs_pc_type#mg"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#ASM,0"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#ASM,1"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#ASM,1##--addOverlap#1"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#ASM,1##-geneo_offload"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#ASM,H1"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#ASM,H1#--addOverlap#1"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#ASM,H1#-geneo_offload"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#ASM,E1"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#ASM,E1#--addOverlap#1"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#ASM,E1#-geneo_offload"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#SORAS,0"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#SORAS,2"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#SORAS,2##--addOverlap#1"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#SORAS,2##-geneo_offload"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#SORAS,H2"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#SORAS,H2#--addOverlap#1"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#SORAS,H2#-geneo_offload"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#SORAS,E2"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#SORAS,E2#--addOverlap#1"
-PC="${PC} -igs_pc_type#geneo#-geneo_lvl#SORAS,E2#-geneo_offload"
-IGS_TYPE_OPT=("-igs_ksp_type#gmres") # "-igs_ksp_type#cg")
-IGS_OPT="-igs_ksp_max_it 1000 -igs_ksp_gmres_restart 1000" # Forbid GMRES restart (by imposing restart = max its).
-IGS_OPT="${IGS_OPT} -options_left no" # Get rid of unused option warnings with options_left (get clean logs).
+PC="-pc_type#bjacobi -pc_type#mg"
+PC="${PC} -pc_type#geneo#-geneo_lvl#ASM,0"
+PC="${PC} -pc_type#geneo#-geneo_lvl#ASM,1"
+PC="${PC} -pc_type#geneo#-geneo_lvl#ASM,1##--addOverlap#1"
+PC="${PC} -pc_type#geneo#-geneo_lvl#ASM,1##-geneo_offload"
+PC="${PC} -pc_type#geneo#-geneo_lvl#ASM,H1"
+PC="${PC} -pc_type#geneo#-geneo_lvl#ASM,H1#--addOverlap#1"
+PC="${PC} -pc_type#geneo#-geneo_lvl#ASM,H1#-geneo_offload"
+PC="${PC} -pc_type#geneo#-geneo_lvl#ASM,E1"
+PC="${PC} -pc_type#geneo#-geneo_lvl#ASM,E1#--addOverlap#1"
+PC="${PC} -pc_type#geneo#-geneo_lvl#ASM,E1#-geneo_offload"
+PC="${PC} -pc_type#geneo#-geneo_lvl#SORAS,0"
+PC="${PC} -pc_type#geneo#-geneo_lvl#SORAS,2"
+PC="${PC} -pc_type#geneo#-geneo_lvl#SORAS,2##--addOverlap#1"
+PC="${PC} -pc_type#geneo#-geneo_lvl#SORAS,2##-geneo_offload"
+PC="${PC} -pc_type#geneo#-geneo_lvl#SORAS,H2"
+PC="${PC} -pc_type#geneo#-geneo_lvl#SORAS,H2#--addOverlap#1"
+PC="${PC} -pc_type#geneo#-geneo_lvl#SORAS,H2#-geneo_offload"
+PC="${PC} -pc_type#geneo#-geneo_lvl#SORAS,E2"
+PC="${PC} -pc_type#geneo#-geneo_lvl#SORAS,E2#--addOverlap#1"
+PC="${PC} -pc_type#geneo#-geneo_lvl#SORAS,E2#-geneo_offload"
+KSP_OPT=("-ksp_type#gmres") # "-ksp_type#cg")
+OPT="-ksp_max_it 1000 -ksp_gmres_restart 1000" # Forbid GMRES restart (by imposing restart = max its).
+OPT="${OPT} -options_left no" # Get rid of unused option warnings with options_left (get clean logs).
 GENEO_L1_DLS=("-dls1_pc_factor_mat_solver_package#mumps") # "-dls1_pc_factor_mat_solver_package#superlu")
 GENEO_L1_OPTIM=("-geneo_optim#0.00" "-geneo_optim#0.02")
 GENEO_L2_TAU_GAMMA=("-geneo_tau#0.1#-geneo_gamma#8." "-geneo_tau#0.2#-geneo_gamma#12.")
@@ -55,7 +55,7 @@ GENEO_L2_ELS_OPT="-els2_eps_max_it 50" # Caution: the more iterations are perfor
 GENEO_L2_ELS_TOL="-els2_eps_tol 1.e-02" # Caution: the most precise the tolerance is, the more the eigen solve is costly.
 GENEO_OPT="" # "-geneo_cut 10"
 MUMPS_OPT="-mat_mumps_cntl_1 0.01 -mat_mumps_cntl_3 -0.00001 -mat_mumps_cntl_4 0.00001" # Pivoting thresholds (mandatory for physical cases).
-MG_OPT="-igs_pc_mg_cycle_type w -igs_pc_mg_smoothup 5 -igs_pc_mg_smoothdown 5"
+MG_OPT="-pc_mg_cycle_type w -pc_mg_smoothup 5 -pc_mg_smoothdown 5"
 SUPERLU_OPT="-mat_superlu_replacetinypivot -mat_superlu_equil -mat_superlu_rowperm LargeDiag -mat_superlu_colperm NATURAL"
 SUPERLUDIST_OPT="-mat_superlu_dist_replacetinypivot -mat_superlu_dist_equil -mat_superlu_dist_rowperm LargeDiag -mat_superlu_dist_colperm NATURAL"
 VERBOSE="NO"
@@ -88,9 +88,9 @@ do
       do
         for p in "${PC_ARRAY[@]}"
         do
-          for k in "${IGS_TYPE_OPT[@]}"
+          for k in "${KSP_OPT[@]}"
           do
-            OTHER_OPT="${IGS_OPT}"
+            OTHER_OPT="${OPT}"
 
             unset OPT_ARRAY
             if [[ "${p}" == *"bjacobi"* ]]; then
@@ -132,14 +132,14 @@ do
               INP="--inpLibA ./@CMAKE_SHARED_LIBRARY_PREFIX@genlaplacian@CMAKE_SHARED_LIBRARY_SUFFIX@"
               INP="${INP} --size#${s}#--weakScaling#${w}#--kappa#2.#lin#--debug#--inpEps#0.0001"
 
-              EPS="-igs_ksp_atol ${t} -igs_ksp_rtol ${t}";
+              EPS="-ksp_atol ${t} -ksp_rtol ${t}";
               if [[ "${p}" == *"geneo"*"1"* ]] || [[ "${p}" == *"geneo"*"2"* ]]; then # GenEO-1, GenEO-2.
                 EPS="${EPS} ${GENEO_L2_ELS_TOL}";
               fi
 
               KSP_CMD="${k//[#]/ }"
               KSP_LOG="${k//[#]/}"; KSP_LOG="${KSP_LOG//-/}"
-              KSP_LOG="${KSP_LOG//igs_ksp_type/}"
+              KSP_LOG="${KSP_LOG//ksp_type/}"
 
               OPT_CMD="${o//[#]/ }"
               OPT_LOG="${o//[#]/:}"; OPT_LOG="${OPT_LOG//-/}"
@@ -149,7 +149,7 @@ do
 
               PC_CMD="${p//[#]/ }"
               PC_LOG="${p//[#]/}"; PC_LOG="${PC_LOG//-/}"; PC_LOG="${PC_LOG//,/}"
-              PC_LOG="${PC_LOG//igs_pc_type/}"; PC_LOG="${PC_LOG//addOverlap/overlap}"
+              PC_LOG="${PC_LOG//pc_type/}"; PC_LOG="${PC_LOG//addOverlap/overlap}"
               PC_LOG="${PC_LOG//geneo_lvl/}"; PC_LOG="${PC_LOG//geneo_offload/offload}"
 
               unset CMD


### PR DESCRIPTION
The most simple way for that is to suppress the "igs" prefix solver.